### PR TITLE
function: use a WeakMap to store Callback buffers

### DIFF
--- a/lib/function.js
+++ b/lib/function.js
@@ -38,6 +38,8 @@ function Function (retType, argTypes, abi) {
   this.retType = ref.coerceType(retType)
   this.argTypes = argTypes.map(ref.coerceType)
   this.abi = null == abi ? bindings.FFI_DEFAULT_ABI : abi
+
+  this._pointers = new WeakMap()
 }
 
 /**
@@ -70,7 +72,12 @@ Function.prototype.indirection = 1
  */
 
 Function.prototype.toPointer = function toPointer (fn) {
-  return Callback(this.retType, this.argTypes, this.abi, fn)
+  var cb = this._pointers.get(fn)
+  if (!cb) {
+    cb = Callback(this.retType, this.argTypes, this.abi, fn)
+    this._pointers.set(fn, cb);
+  }
+  return cb
 }
 
 /**

--- a/test/ffi_tests.cc
+++ b/test/ffi_tests.cc
@@ -181,10 +181,14 @@ typedef void (*cb)(void);
 
 static cb callback = NULL;
 
+void SetCbFunc(cb cb) {
+  callback = cb;
+}
+
 NAN_METHOD(SetCb) {
   Nan::HandleScope();
   char *buf = Buffer::Data(info[0].As<Object>());
-  callback = (cb)buf;
+  SetCbFunc((cb)buf);
   info.GetReturnValue().SetUndefined();
 }
 
@@ -315,6 +319,7 @@ void Initialize(Handle<Object> target) {
   target->Set(Nan::New<String>("int_array").ToLocalChecked(), WrapPointer((char *)int_array));
   target->Set(Nan::New<String>("array_in_struct").ToLocalChecked(), WrapPointer((char *)array_in_struct));
   target->Set(Nan::New<String>("callback_func").ToLocalChecked(), WrapPointer((char *)callback_func));
+  target->Set(Nan::New<String>("set_cb_func").ToLocalChecked(), WrapPointer((char *)SetCbFunc));
   target->Set(Nan::New<String>("play_ping_pong").ToLocalChecked(), WrapPointer((char *)play_ping_pong));
 }
 


### PR DESCRIPTION
See #241.

Before, if you were using the `ffi.Function` "type" and passed
a callback function in such that a C library stored the function
pointer for later, then we want to prevent that callback pointer
from being garbage collected until _after_ the JS callback function
is collected.

However, the the WeakMap is in effect just a regular Map, since
the Callback buffers retain a reference to the JS function, which
is also the `key` we are using for the map. The result is that
in order for the callback pointer memory to be cleaned up you
need to not only nullify the JS callback reference, but *also*
the FunctionType instance references.

This is tricky, since if you pass the FunctionType to
`ffi.ForeignFunction` then the foreign function instance will
also retain a reference to the function type. So you need to
nullify the foreign function reference as well if you are wanting
to free the callback pointer's memory.node-ffi